### PR TITLE
Handle error

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -151,8 +151,9 @@ class admin_plugin_sync extends DokuWiki_Admin_Plugin {
                    $this->profiles[$this->profno]['type'] == 1){
                     $pages = $this->_getSyncList('pages');
                 }
-                if($this->profiles[$this->profno]['type'] == 0 ||
-                   $this->profiles[$this->profno]['type'] == 2){
+                if(($this->profiles[$this->profno]['type'] == 0 ||
+                   $this->profiles[$this->profno]['type'] == 2)
+                    && $pages !== false ){
                     $media = $this->_getSyncList('media');
                 }
             }


### PR DESCRIPTION
Currently if the request for remote pages is a success but the one for media fails,
then we have the error message "Failed to fetch remote file list" but the list of pages
is displayed, and (if php warnings are enabled) we then have
Warning: Invalid argument supplied for foreach() in sync/admin.php on line 546

It's therefore not quite clear for the user if it's a success or a failure
(and in particular if he can go on)

The goal of this patch is to keep only the "failed to fetch ..." error message
