### PR TITLE
Fix sync check failure when there are no media files to be synced

### DIFF
--- a/Profile.php
+++ b/Profile.php
@@ -21,7 +21,7 @@ class Profile {
     /** @var  array the options we use to query the files to sync */
     protected $syncoptions;
     /** @var  array the list of files to sync */
-    protected $synclist = [];
+    protected $synclist = [self::TYPE_PAGES => [], self::TYPE_MEDIA => []];
 
     /**
      * Profile constructor.


### PR DESCRIPTION
The sync script fails if the sync list of files does not exist at all. This PR makes sure it exists. It is handled well when empty. 