### PR TITLE
Constructor renamed to __construct per php 8

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -15,7 +15,7 @@ class admin_plugin_sync extends DokuWiki_Admin_Plugin {
     /**
      * Constructor.
      */
-    function admin_plugin_sync(){
+    function __construct(){
         $this->_profileLoad();
         $this->profno = preg_replace('/[^0-9]+/','',$_REQUEST['no']);
     }


### PR DESCRIPTION
The prior constructor is never invoked on dokuweb 2022-07-31 "Igor" running inside docker so newly saved profiles are lost on page refreshes and thus no synch is possible. 
With this update the plug-in able to compute differences and synch in both directions.
