### PR TITLE
Fix error on main screen

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -23,9 +23,9 @@ class Client extends \IXR_Client {
     }
 
     /** @inheritdoc */
-    public function query() {
+    public function query(...$args) {
         $ok = call_user_func_array('parent::query', func_get_args());
-        $code = $this->getErrorCode();
+        $code = @$this->getErrorCode();
         if($code === -32300) $code = -1 * $this->status; // use http status on transport errors
         if(!$ok) {
             // when a file context is given include it in the exception


### PR DESCRIPTION
This PR fixes the following error on plugin mainpage:

```
2024-03-07 15:35:05
E_COMPILE_ERROR: Declaration of dokuwiki\plugin\sync\Client::query() must be compatible with dokuwiki\Remote\IXR\Client::query(...$args)
/home/robertinho/public_html/wiki/lib/plugins/sync/Client.php(26)
#0 [internal function]: dokuwiki\ErrorHandler::fatalShutdown()
#1 {main}
```

Also, this adds a "@" before geterrorCode() call because it was failing on 200 status and the following errors was being thrown on page when PHP "display_errors" was set to true (the error isn't shown on page anymore but it's logged on DokuWiki logs):

```
2024-03-07 15:33:39
E_WARNING: Attempt to read property "code" on null
/home/robertinho/public_html/wiki/vendor/kissifrot/php-ixr/src/Client/Client.php(182)
#0 /home/robertinho/public_html/wiki/vendor/kissifrot/php-ixr/src/Client/Client.php(182): dokuwiki\ErrorHandler::errorHandler(2, 'Attempt to read...', '/home/robertinh...', 182)
#1 /home/robertinho/public_html/wiki/lib/plugins/sync/Client.php(28): IXR\Client\Client->getErrorCode()
#2 /home/robertinho/public_html/wiki/lib/plugins/sync/Client.php(49): dokuwiki\plugin\sync\Client->query('dokuwiki.login', 'username', 'password')
#3 /home/robertinho/public_html/wiki/lib/plugins/sync/Client.php(22): dokuwiki\plugin\sync\Client->login('username', 'password')
#4 /home/robertinho/public_html/wiki/lib/plugins/sync/Profile.php(38): dokuwiki\plugin\sync\Client->__construct('https://wiki.ne...', 'username', 'password', '180')
#5 /home/robertinho/public_html/wiki/lib/plugins/sync/ProfileManager.php(30): dokuwiki\plugin\sync\Profile->__construct(Array)
#6 /home/robertinho/public_html/wiki/lib/plugins/sync/admin.php(113): dokuwiki\plugin\sync\ProfileManager->getProfile(0)
#7 /home/robertinho/public_html/wiki/lib/plugins/sync/admin.php(98): admin_plugin_sync->profileInfo()
#8 /home/robertinho/public_html/wiki/inc/template.php(205): admin_plugin_sync->html()
#9 /home/robertinho/public_html/wiki/inc/Action/Admin.php(43): tpl_admin()
#10 /home/robertinho/public_html/wiki/inc/template.php(120): dokuwiki\Action\Admin->tplContent()
#11 [internal function]: tpl_content_core('admin')
#12 /home/robertinho/public_html/wiki/inc/Extension/Event.php(134): call_user_func_array('tpl_content_cor...', Array)
#13 /home/robertinho/public_html/wiki/inc/Extension/Event.php(200): dokuwiki\Extension\Event->trigger('tpl_content_cor...', true)
#14 /home/robertinho/public_html/wiki/inc/template.php(102): dokuwiki\Extension\Event::createAndTrigger('TPL_ACT_RENDER', 'admin', 'tpl_content_cor...')
#15 /home/robertinho/public_html/wiki/lib/tpl/readthedokus/tpl_parts/tpl_content.html(5): tpl_content(false)
#16 /home/robertinho/public_html/wiki/inc/template.php(1785): include('/home/robertinh...')
#17 /home/robertinho/public_html/wiki/lib/tpl/readthedokus/main.php(42): tpl_includeFile('/home/robertinh...')
#18 /home/robertinho/public_html/wiki/inc/actions.php(30): include('/home/robertinh...')
#19 /home/robertinho/public_html/wiki/doku.php(131): act_dispatch()
#20 {main}
2024-03-07 15:33:40
E_WARNING: Attempt to read property "code" on null
/home/robertinho/public_html/wiki/vendor/kissifrot/php-ixr/src/Client/Client.php(182)
#0 /home/robertinho/public_html/wiki/vendor/kissifrot/php-ixr/src/Client/Client.php(182): dokuwiki\ErrorHandler::errorHandler(2, 'Attempt to read...', '/home/robertinh...', 182)
#1 /home/robertinho/public_html/wiki/lib/plugins/sync/Client.php(28): IXR\Client\Client->getErrorCode()
#2 /home/robertinho/public_html/wiki/lib/plugins/sync/Profile.php(71): dokuwiki\plugin\sync\Client->query('dokuwiki.getVer...')
#3 /home/robertinho/public_html/wiki/lib/plugins/sync/admin.php(114): dokuwiki\plugin\sync\Profile->getRemotVersion()
#4 /home/robertinho/public_html/wiki/lib/plugins/sync/admin.php(98): admin_plugin_sync->profileInfo()
#5 /home/robertinho/public_html/wiki/inc/template.php(205): admin_plugin_sync->html()
#6 /home/robertinho/public_html/wiki/inc/Action/Admin.php(43): tpl_admin()
#7 /home/robertinho/public_html/wiki/inc/template.php(120): dokuwiki\Action\Admin->tplContent()
#8 [internal function]: tpl_content_core('admin')
#9 /home/robertinho/public_html/wiki/inc/Extension/Event.php(134): call_user_func_array('tpl_content_cor...', Array)
#10 /home/robertinho/public_html/wiki/inc/Extension/Event.php(200): dokuwiki\Extension\Event->trigger('tpl_content_cor...', true)
#11 /home/robertinho/public_html/wiki/inc/template.php(102): dokuwiki\Extension\Event::createAndTrigger('TPL_ACT_RENDER', 'admin', 'tpl_content_cor...')
#12 /home/robertinho/public_html/wiki/lib/tpl/readthedokus/tpl_parts/tpl_content.html(5): tpl_content(false)
#13 /home/robertinho/public_html/wiki/inc/template.php(1785): include('/home/robertinh...')
#14 /home/robertinho/public_html/wiki/lib/tpl/readthedokus/main.php(42): tpl_includeFile('/home/robertinh...')
#15 /home/robertinho/public_html/wiki/inc/actions.php(30): include('/home/robertinh...')
#16 /home/robertinho/public_html/wiki/doku.php(131): act_dispatch()
```